### PR TITLE
fix: producing illegal fabric mod ids for some includes

### DIFF
--- a/minecraft-codev-fabric/src/main/kotlin/net/msrandom/minecraftcodev/fabric/task/JarInJar.kt
+++ b/minecraft-codev-fabric/src/main/kotlin/net/msrandom/minecraftcodev/fabric/task/JarInJar.kt
@@ -1,14 +1,13 @@
 package net.msrandom.minecraftcodev.fabric.task
 
+import com.google.common.hash.Hashing
 import kotlinx.serialization.json.*
 import net.msrandom.minecraftcodev.core.MinecraftCodevPlugin.Companion.json
 import net.msrandom.minecraftcodev.core.utils.getAsPath
 import net.msrandom.minecraftcodev.core.utils.toPath
 import net.msrandom.minecraftcodev.core.utils.zipFileSystem
 import net.msrandom.minecraftcodev.fabric.MinecraftCodevFabricPlugin
-import net.msrandom.minecraftcodev.includes.IncludedJarInfo
 import net.msrandom.minecraftcodev.includes.IncludesJar
-import org.gradle.api.Task
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.Internal
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -38,6 +37,7 @@ abstract class JarInJar : IncludesJar() {
         super.copy()
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     private fun addIncludedJarMetadata() {
         val info = includedJarInfo.get()
 
@@ -65,7 +65,15 @@ abstract class JarInJar : IncludesJar() {
 
                 val metadata = buildJsonObject {
                     put("schemaVersion", 1)
-                    put("id", "${group}_$name")
+                    put("id", "${group}_$name".lowercase()
+                        .replace(".", "_")
+                        .dropWhile { char -> char !in 'a'..'z' }
+                        .let { modId ->
+                            if (modId.length > 64) {
+                                val hash = Hashing.sha256().hashString(modId, Charsets.UTF_8).asBytes().toHexString()
+                                modId.substring(0, 50) + hash.substring(0, 14)
+                            } else modId
+                        })
                     put("version", version)
                     put("name", name)
 


### PR DESCRIPTION
In case the groupId or moduleName contained a capital letter it created a modId that didn't match the expected pattern `^[a-z][a-z0-9-_]{1,63}$`, it now mimics the behaviour of fabric-loom. The only difference being not including the classifier, and dropping every prefixed non a-z char.